### PR TITLE
RC 2025-08-20

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,12 +11,6 @@ The auro-tabpanel element should only be used inside an AuroTabgroup element.
 | `selected` | `selected` | `Boolean` | "false" | Mark the tab as selected tab. |
 | `variant`  | `variant`  | `string`  | "false" |                               |
 
-## Events
-
-| Event          |
-|----------------|
-| `tab-selected` |
-
 
 # auro-tabgroup
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,11 +27,19 @@ cached and therefore, changes during runtime work.
 
 ## Properties
 
-| Property | Type      |
-|----------|-----------|
-| `busy`   | `boolean` |
-| `panels` |           |
-| `tabs`   |           |
+| Property        | Attribute       | Type      | Default |
+|-----------------|-----------------|-----------|---------|
+| `busy`          |                 | `boolean` |         |
+| `panels`        |                 |           |         |
+| `selectOnFocus` | `selectOnFocus` | `boolean` | "false" |
+| `tabs`          |                 |           |         |
+
+## Methods
+
+| Method             | Type                          | Description                                |
+|--------------------|-------------------------------|--------------------------------------------|
+| `selectTab`        | `(newTab: HTMLElement): void` | **newTab**: Selected auro-tab.             |
+| `selectTabByIndex` | `(index: number): void`       | **index**: The index of the tab to select. |
 
 ## Slots
 

--- a/src/auro-tab.js
+++ b/src/auro-tab.js
@@ -31,6 +31,16 @@ export class AuroTab extends LitElement {
       },
 
       /**
+       * @property {boolean} focused - Indicates whether the tab is focused.
+       * @default false
+       * @private
+       */
+      focused: {
+        type: Boolean,
+        state: true,
+      },
+
+      /**
        * @property {boolean} disabled - Indicates whether the tab is disabled.
        * @default false
        */
@@ -97,6 +107,18 @@ export class AuroTab extends LitElement {
       event.preventDefault();
     }
   };
+
+  /**
+   * Sets the focus state for the tab.
+   * @param {boolean} focused - Whether the tab should be focused.
+   * @private
+   */
+  setFocused(focused) {
+    if (focused) this.focus();
+    this.focused = focused;
+    this.setAttribute("tabindex", focused ? 0 : -1);
+    this.dispatchCustomEvent(focused ? "tab-focused" : "tab-blurred", this);
+  }
 
   /**
    * @private
@@ -167,18 +189,28 @@ export class AuroTab extends LitElement {
    */
   updateSelected() {
     // Update relevant attributes
-    this.setAttribute("tabindex", this.selected ? 0 : -1);
+    this.setAttribute("tabindex", this.selected || this.focused ? 0 : -1);
     this.setAttribute("aria-selected", this.selected ? "true" : "false");
 
     // Emit event if this tab is selected
     if (this.selected) {
-      const event = new Event("tab-selected", {
-        bubbles: true,
-        composed: true,
-        detail: this.selected,
-      });
-      this.dispatchEvent(event);
+      this.dispatchCustomEvent("tab-selected", this);
     }
+  }
+
+  /**
+   * Dispatch a custom event from the component.
+   * @param {string} eventName - The name of the event to dispatch.
+   * @param {*} detail - The detail payload to include with the event.
+   * @private
+   */
+  dispatchCustomEvent(eventName, detail) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      composed: true,
+      detail,
+    });
+    this.dispatchEvent(event);
   }
 
   /**

--- a/src/auro-tab.js
+++ b/src/auro-tab.js
@@ -63,6 +63,7 @@ export class AuroTab extends LitElement {
     this.setId();
     this.setInitialValues();
     this.setAttributes();
+    this.addEventListeners();
   }
 
   /**
@@ -75,6 +76,27 @@ export class AuroTab extends LitElement {
   static incrementInstanceCount() {
     AuroTab.instanceCount = (AuroTab.instanceCount || 0) + 1;
   }
+
+  /**
+   * Add event listeners for the component.
+   * @returns {void}
+   * @private
+   */
+  addEventListeners() {
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  /**
+   * Handles the keydown event for the tab.
+   * @param {KeyboardEvent} event - The keydown event.
+   * @private
+   */
+  onKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      this.selected = true;
+      event.preventDefault();
+    }
+  };
 
   /**
    * @private

--- a/src/auro-tabgroup.js
+++ b/src/auro-tabgroup.js
@@ -224,6 +224,7 @@ export class AuroTabgroup extends LitElement {
    */
   bindMethods() {
     this.handleTabSelected = this.handleTabSelected.bind(this);
+    this.handleTabFocused = this.handleTabFocused.bind(this);
   }
 
   /**
@@ -272,6 +273,7 @@ export class AuroTabgroup extends LitElement {
    */
   addEventListeners() {
     this.addEventListener("tab-selected", this.handleTabSelected);
+    this.addEventListener("tab-focused", this.handleTabFocused);
     this.addEventListener("keydown", this.onKeyDown);
     this.addEventListener("click", this.onClick);
   }
@@ -407,8 +409,12 @@ export class AuroTabgroup extends LitElement {
 
     // Focus to the new tab, that has been determined in the switch-case.
     const newTab = tabs[newIdx];
+
     if (newTab) {
-      newTab.focus();
+      // Set focus states for tabs
+      this.tabs.current.forEach((tab, index) => {
+        tab.setFocused(tab === newTab);
+      });
 
       if (this.selectOnFocus) {
         this.selectTab(newTab);
@@ -465,6 +471,16 @@ export class AuroTabgroup extends LitElement {
       width: `${tab.clientWidth}px`,
       left: `${tab.offsetLeft - 0.5}px`,
     };
+  }
+
+  /**
+   * Handles the tab focus event.
+   * @param {FocusEvent} event - The focus event.
+   * @private
+   */
+  handleTabFocused(event) {
+    const tab = event.target;
+    this.focusedTabIdx = this.tabs.current.indexOf(tab) || 0;
   }
 
   /**

--- a/src/auro-tabgroup.js
+++ b/src/auro-tabgroup.js
@@ -51,6 +51,15 @@ export class AuroTabgroup extends LitElement {
       },
 
       /**
+       * @property {Boolean} selectOnFocus - Whether or not to select the tab on focus.
+       * @default false
+       */
+      selectOnFocus: {
+        type: Boolean,
+        reflect: true,
+      },
+
+      /**
        * @property {Object} sliderStyles - The styles for the slider element.
        * @default {}
        * @private
@@ -190,6 +199,7 @@ export class AuroTabgroup extends LitElement {
     // Dynamic Properties
     this.scrollPosition = 0;
     this.sliderStyles = {};
+    this.selectOnFocus = false;
 
     // Static Properties
     /**
@@ -213,7 +223,7 @@ export class AuroTabgroup extends LitElement {
    * @private
    */
   bindMethods() {
-    this.setSliderStyles = this.setSliderStyles.bind(this);
+    this.handleTabSelected = this.handleTabSelected.bind(this);
   }
 
   /**
@@ -261,7 +271,7 @@ export class AuroTabgroup extends LitElement {
    * @private
    */
   addEventListeners() {
-    this.addEventListener("tab-selected", this.setSliderStyles);
+    this.addEventListener("tab-selected", this.handleTabSelected);
     this.addEventListener("keydown", this.onKeyDown);
     this.addEventListener("click", this.onClick);
   }
@@ -298,8 +308,7 @@ export class AuroTabgroup extends LitElement {
   };
 
   /**
-   * @description Function handler when selecting an auro-tab.
-   * @private
+   * @description Select an auro tab by reference
    * @param {HTMLElement} newTab Selected auro-tab.
    */
   selectTab(newTab) {
@@ -334,6 +343,17 @@ export class AuroTabgroup extends LitElement {
     if (!newTab.panel) {
       // eslint-disable-next-line no-console
       console.warn(`No panel with id ${newTab.id}`);
+    }
+  }
+
+  /**
+   * @description Select a tab by its index.
+   * @param {number} index - The index of the tab to select.
+   */
+  selectTabByIndex(index) {
+    const tab = this.tabs.current[index];
+    if (tab) {
+      this.selectTab(tab);
     }
   }
 
@@ -378,6 +398,8 @@ export class AuroTabgroup extends LitElement {
         return;
     }
 
+    this.focusedTabIdx = newIdx;
+
     // The browser might have some native functionality bound to the arrow
     // keys, home or end. The element calls `preventDefault()` to prevent the
     // browser from taking any actions.
@@ -387,7 +409,10 @@ export class AuroTabgroup extends LitElement {
     const newTab = tabs[newIdx];
     if (newTab) {
       newTab.focus();
-      this.selectTab(newTab);
+
+      if (this.selectOnFocus) {
+        this.selectTab(newTab);
+      }
     }
   }
 
@@ -420,7 +445,7 @@ export class AuroTabgroup extends LitElement {
    * @param {Event<tab-selected>} event Dispatched from auro-tab.
    * @private
    */
-  setSliderStyles(event) {
+  handleTabSelected(event) {
     // Set the slider width to zero by default
     this.sliderStyles.width = 0;
 
@@ -431,6 +456,9 @@ export class AuroTabgroup extends LitElement {
     if (!tab) {
       return;
     }
+
+    // Update the selected tab if it was set externally
+    this.selectTab(tab);
 
     // Update the slider styles based on the tab that was focused
     this.sliderStyles = {
@@ -497,7 +525,7 @@ export class AuroTabgroup extends LitElement {
    */
   setResizeObserver(tabGroupContainer) {
     this.resizeObserver = new ResizeObserver(() => {
-      this.setSliderStyles({ target: this.currentTab });
+      this.handleTabSelected({ target: this.currentTab });
     });
 
     const tabGroup = tabGroupContainer.querySelector(".tabgroup");


### PR DESCRIPTION
fix: better focus handling for keyboard controls #75
  - Focusing a tab now changes it's tabindex so we maintain the user's focus during tab operations
  - Tabgroup now handles setting the focused state of all tabs when a tab is focused
  - Added event for tab-blurred

feat: add selectOnFocus property to toggle selecting tabs on focus when arrow keys are pressed

## Summary by Sourcery

Enhance keyboard navigation and focus handling in AuroTab and AuroTabgroup, introduce selectOnFocus option for automatic selection on focus, and document new APIs.

New Features:
- Add selectOnFocus property to toggle selecting tabs on focus
- Expose selectTabByIndex method to programmatically select tabs by index
- Dispatch new "tab-focused" and "tab-blurred" events from AuroTab
- Enable selecting a tab via Enter or Space key

Bug Fixes:
- Fix keyboard focus handling by updating tabindex of focused tabs

Enhancements:
- Improve focus management by coordinating focused state across AuroTab and AuroTabgroup
- Update Tabgroup navigation to maintain focus states and optionally select tabs on focus

Documentation:
- Document selectOnFocus property and selectTabByIndex method in API reference