### PR TITLE
Tab keydown, ignore bubbling

### DIFF
--- a/apiExamples/custom-content.html
+++ b/apiExamples/custom-content.html
@@ -24,6 +24,14 @@
     </auro-tabpanel>
     <auro-tabpanel>
       <span>Tab 2 Content</span>
+
+      <!-- a radio group -->
+      <auro-radio-group horizontal>
+        <span slot="legend">Accordion Test</span>
+        <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="creditordebit" value="credit"></auro-radio>
+        <auro-radio id="basicGroupRadio2" label="Apple Pay" name="applePay" value="applePay"></auro-radio>
+        <auro-radio id="basicGroupRadio3" label="Alaska Airlines Commercial Account" name="alaskaCommercial" value="alaskaCommercial"></auro-radio>
+      </auro-radio-group>
     </auro-tabpanel>
   </div>
 </auro-tabgroup>

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,6 +26,10 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/demoWrapper.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/elementDemoStyles.css" />
 
+    <!-- Auro radio group for examples -->
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-radio/+esm"></script>
+
+
     <style>
       /*
         For demo purposes only, the above elementDemoStyles

--- a/src/auro-tabgroup.js
+++ b/src/auro-tabgroup.js
@@ -370,6 +370,12 @@ export class AuroTabgroup extends LitElement {
       return;
     }
 
+    // Ignore events from non-tab elements and/or non tablist elements
+    const role = event.target.getAttribute("role");
+    if (role !== "tab" && role !== "tablist") {
+      return;
+    }
+
     // The switch-case will determine which tab should be marked as focused
     // depending on the key that was pressed.
     const tabs = this.allTabs;

--- a/test/auro-tabs.test.js
+++ b/test/auro-tabs.test.js
@@ -45,10 +45,11 @@ describe("auro-tabgroup", () => {
     await expect(el.checkVisibility()).to.be.true;
   });
 
-  it("trigger keyhandler", async () => {
+  it.skip("trigger keyhandler", async () => {
     const el = await fixture(getTabGroup());
     await elementUpdated(el);
 
+    const tablistRootDiv = el.shadowRoot.querySelector("[role='tablist']");
     const tabs = el.allTabs;
     const panels = el.allPanels;
 
@@ -66,11 +67,13 @@ describe("auro-tabgroup", () => {
     const expectedIndex = [1, 0, 0, 4, 0, 4];
 
     for (let i = 0; i < arrayKeys.length; i++) {
-      el.dispatchEvent(
+      tablistRootDiv.dispatchEvent(
         new KeyboardEvent("keydown", {
           key: arrayKeys[i],
         }),
       );
+      // DEBUG - check role attribute on element
+      console.log(tablistRootDiv.getAttribute("role"));
 
       await elementUpdated(el);
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

NOTE ON SKIPPED TEST: @jason-capsule42 and i approved this skip to get an RC branch out, I'll continue to work on a fix afterward

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent arrow key events from non-tab elements in the tabgroup, add radio group examples to demos, and update tests for keyboard handling

Bug Fixes:
- Filter keydown events to ignore elements without role "tab" or "tablist" to prevent unintended arrow key bubbling

Documentation:
- Add an auro-radio-group example to custom-content.html
- Include the auro-formkit radio script in the demo index.html

Tests:
- Skip the flaky keyhandler test and update it to dispatch events on the tablist element