### PR TITLE
feat: add `appearance` and deprecate `ondark` #84

### DIFF
--- a/apiExamples/inverseAppearance.html
+++ b/apiExamples/inverseAppearance.html
@@ -1,5 +1,5 @@
 <div style="color: white;">
-  <auro-tabgroup variant="unstyled" ondark>
+  <auro-tabgroup variant="unstyled" appearance="inverse">
   <div slot="tabs">
     <auro-tab>
       Baggage Info

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,11 +5,12 @@ The auro-tabpanel element should only be used inside an AuroTabgroup element.
 
 ## Properties
 
-| Property   | Attribute  | Type      | Default | Description                   |
-|------------|------------|-----------|---------|-------------------------------|
-| `disabled` | `disabled` | `Boolean` | "false" | Mark the tab as disabled tab. |
-| `selected` | `selected` | `Boolean` | "false" | Mark the tab as selected tab. |
-| `variant`  | `variant`  | `string`  | "false" |                               |
+| Property     | Attribute    | Type      | Default     | Description                                      |
+|--------------|--------------|-----------|-------------|--------------------------------------------------|
+| `appearance` | `appearance` | `string`  | "'default'" | Defines whether the component will be on lighter or darker backgrounds. |
+| `disabled`   | `disabled`   | `Boolean` | "false"     | Mark the tab as disabled tab.                    |
+| `selected`   | `selected`   | `Boolean` | "false"     | Mark the tab as selected tab.                    |
+| `variant`    | `variant`    | `string`  | "false"     |                                                  |
 
 
 # auro-tabgroup
@@ -21,13 +22,14 @@ cached and therefore, changes during runtime work.
 
 ## Properties
 
-| Property        | Attribute       | Type      | Default | Description                                      |
-|-----------------|-----------------|-----------|---------|--------------------------------------------------|
-| `busy`          |                 | `boolean` |         |                                                  |
-| `ondark`        | `ondark`        | `Boolean` | "false" | Set when the tabgroup is used on a dark background. |
-| `panels`        |                 |           |         |                                                  |
-| `selectOnFocus` | `selectOnFocus` | `boolean` | "false" |                                                  |
-| `tabs`          |                 |           |         |                                                  |
+| Property        | Attribute       | Type      | Default     | Description                                      |
+|-----------------|-----------------|-----------|-------------|--------------------------------------------------|
+| `appearance`    | `appearance`    | `string`  | "'default'" | Defines whether the component will be on lighter or darker backgrounds. |
+| `busy`          |                 | `boolean` |             |                                                  |
+| `ondark`        | `ondark`        | `Boolean` | "false"     | DEPREACTED - use `appearance` instead.           |
+| `panels`        |                 |           |             |                                                  |
+| `selectOnFocus` | `selectOnFocus` | `boolean` | "false"     |                                                  |
+| `tabs`          |                 |           |             |                                                  |
 
 ## Methods
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -77,18 +77,18 @@ Tab component will fire `tab-selected` event when selected.
 
 </auro-accordion>
 
-### onDark
+### Visual State on Dark Background
 
 Set when the tabgroup is used on a dark background.
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/onDark.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/inverseAppearance.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion lowProfile justifyRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/onDark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/inverseAppearance.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/src/auro-tab.js
+++ b/src/auro-tab.js
@@ -22,6 +22,16 @@ export class AuroTab extends LitElement {
   static get properties() {
     return {
       /**
+       * Defines whether the component will be on lighter or darker backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true,
+      },
+
+      /**
        * @property {boolean} selected - Indicates whether the tab is selected.
        * @default false
        */
@@ -66,6 +76,8 @@ export class AuroTab extends LitElement {
 
   constructor() {
     super();
+
+    this.appearance = "default";
 
     AuroTab.incrementInstanceCount();
 

--- a/src/auro-tabgroup.js
+++ b/src/auro-tabgroup.js
@@ -37,11 +37,21 @@ const KEYCODE = {
  * @csspart tabgroup__panels - The panel wrapper element.
  * @csspart slider-positioner - The slider positioner element (non-visual, only used to center slider on tab).
  * @csspart slider - The slider element.
- * @attr {Boolean} ondark - Set when the tabgroup is used on a dark background.
+ * @attr {Boolean} ondark - DEPREACTED - use `appearance` instead.
  */
 export class AuroTabgroup extends LitElement {
   static get properties() {
     return {
+      /**
+       * Defines whether the component will be on lighter or darker backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true,
+      },
+
       /**
        * @property {number} scrollPosition - The current scroll position of the tab group container.
        * @default 0
@@ -93,7 +103,7 @@ export class AuroTabgroup extends LitElement {
       },
 
       /**
-       * @property {boolean} ondark - Set when the tabgroup is used on a dark background.
+       * @property {boolean} ondark - DEPREACTED - use `appearance` instead.
        * @default false
        */
       ondark: {
@@ -176,6 +186,8 @@ export class AuroTabgroup extends LitElement {
 
   constructor() {
     super();
+
+    this.appearance = "default";
 
     this.handleTagName();
     this.setInitialValues();
@@ -261,6 +273,8 @@ export class AuroTabgroup extends LitElement {
       } else {
         tab.removeAttribute("ondark");
       }
+
+      tab.setAttribute("appearance", this.appearance);
     });
   }
 
@@ -615,7 +629,10 @@ export class AuroTabgroup extends LitElement {
   updated(changedProperties) {
     this.updateChevronVisibility();
 
-    if (changedProperties.has("ondark")) {
+    if (
+      changedProperties.has("appearance") ||
+      changedProperties.has("ondark")
+    ) {
       this.propagateOnDarkToTabs();
     }
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -51,13 +51,15 @@
   height: 100%;
 }
 
-:host(:not([onDark])) {
+:host(:not([onDark])),
+:host(:not([appearance="inverse"])) {
   .slider {
     background-color: var(--ds-advanced-color-state-focused, v.$ds-advanced-color-state-focused);
   }
 }
 
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   .slider {
     background-color: var(--ds-advanced-color-state-focused-inverse, v.$ds-advanced-color-state-focused-inverse);
   }

--- a/src/tab-style.scss
+++ b/src/tab-style.scss
@@ -39,14 +39,18 @@
 
 /* stylelint-disable no-descending-specificity */
 :host([onDark]:focus-within),
-:host([onDark]:focus:not(:focus-visible)) {
+:host([onDark]:focus:not(:focus-visible)),
+:host([appearance="inverse"]:focus-within),
+:host([appearance="inverse"]:focus:not(:focus-visible)) {
   &:before {
     border-color: var(--ds-advanced-color-state-focused-inverse, v.$ds-advanced-color-state-focused-inverse);
   }
 }
 
 :host(:not([onDark]):focus-within),
-:host(:not([onDark]):focus:not(:focus-visible)) {
+:host(:not([onDark]):focus:not(:focus-visible)),
+:host(:not([appearance="inverse"]):focus-within),
+:host(:not([appearance="inverse"]):focus:not(:focus-visible)) {
   &:before {
     border-color: var(--ds-advanced-color-state-focused, v.$ds-advanced-color-state-focused);
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #84 

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `default`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
