### PR TITLE
AURO SYNC: Add release candidate workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@ body:
   - type: checkboxes
     id: platform
     attributes:
-      label: What devices platform(s) are you seeing the issue on?
+      label: On which platforms are you seeing the issue?
       description: Select all that apply.
       options:
         - label: Desktop

--- a/.github/ISSUE_TEMPLATE/general-support.yaml
+++ b/.github/ISSUE_TEMPLATE/general-support.yaml
@@ -1,5 +1,5 @@
 name: Support Request
-description: Request for assistance with any issue related to the Aurora Design System
+description: Request for assistance with any issue related to the Auro Design System
 type: "Support"
 title: '...provide a title...'
 projects: ["AlaskaAirlines/19"]

--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -18,7 +18,7 @@ body:
     id: context
     attributes:
       label: Additional context
-      description: Add any other context or screenshots about the here.
+      description: Add any other context or screenshots about this story here.
   - type: textarea
     id: exit-criteria
     attributes:

--- a/.github/workflows/dev-demo.yml
+++ b/.github/workflows/dev-demo.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-  pull_request:
 
 jobs:
   action:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,8 +10,5 @@ on:
 jobs:
   action:
     uses: AlaskaAirlines/auro-actions/.github/workflows/pull-request.yml@main
-    with:
-      component: 'tabs'
     secrets:
-      AURO_SURGE_TOKEN: ${{ secrets.AURO_SURGE_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,10 @@
+name: RC Workflow
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'dev'
+
+jobs:
+  action:
+    uses: AlaskaAirlines/auro-actions/.github/workflows/release-candidate.yml@main


### PR DESCRIPTION
Updates the github folder to include the release candidate workflow and other improvements.

## Summary by Sourcery

Add a release candidate GitHub Actions workflow and align repository GitHub configuration with shared Auro standards.

CI:
- Introduce a release candidate workflow that runs on demand and on pushes to the dev branch using shared auro-actions.
- Simplify the pull-request workflow configuration by relying on shared defaults and removing unused secrets.
- Limit the dev demo workflow to run only on pushes to the dev branch.

Documentation:
- Polish GitHub issue templates with clearer wording and corrected Auro branding.